### PR TITLE
Add tests for TorchCox sklearn integration

### DIFF
--- a/src/coxbin/TorchCox.py
+++ b/src/coxbin/TorchCox.py
@@ -9,76 +9,122 @@ torch.autograd.set_detect_anomaly(True)
 
 
 class TorchCox(BaseEstimator):
-    """Fit a Cox model
-    """
+    """Fit a Cox proportional hazards model."""
 
-    def __init__(self, lr=1, random_state=None):
+    def __init__(
+        self, lr=1.0, random_state=None, *, Xnames=None, tname="time", dname="event"
+    ):
         self.random_state = random_state
         self.lr = lr
-        
+        self.Xnames = Xnames
+        self.tname = tname
+        self.dname = dname
+
     def _padToMatch2d(self, inputtens, targetshape):
-        target = torch.full(targetshape, fill_value=-1e3)#torch.zeros(*targetshape)
-        target[:inputtens.shape[0], :inputtens.shape[1]] = inputtens
+        target = torch.full(targetshape, fill_value=-1e3)  # torch.zeros(*targetshape)
+        target[: inputtens.shape[0], : inputtens.shape[1]] = inputtens
         return target
-        
+
     def get_loss(self, tensor, event_tens, num_tied, beta):
-        loss_event = torch.einsum('ik,k->i', event_tens, beta)
-                        
-        XB = torch.einsum('ijk,k->ij', tensor, beta)
-        loss_atrisk = -num_tied*torch.logsumexp(XB, dim=1)
-        
+        loss_event = torch.einsum("ik,k->i", event_tens, beta)
+
+        XB = torch.einsum("ijk,k->ij", tensor, beta)
+        loss_atrisk = -num_tied * torch.logsumexp(XB, dim=1)
+
         loss = torch.sum(loss_event + loss_atrisk)
 
         return -loss
 
-    # the arguments are ignored anyway, so we make them optional
-    def fit(self, df, Xnames=None, tname=None, dname=None, basehaz=True):
-    
-        self.Xnames = Xnames
-        self.tname = tname
-        self.dname = dname
-        
-        #self.random_state_ = check_random_state(self.random_state)
+    def fit(self, X, y, basehaz=True):
+        """Fit the model.
+
+        Parameters
+        ----------
+        X : array-like or DataFrame of shape (n_samples, n_features)
+            The covariate matrix.
+        y : array-like or DataFrame of shape (n_samples, 2)
+            Structured array containing the survival time and event indicator.
+        basehaz : bool, default=True
+            Whether to compute and store the baseline cumulative hazard.
+        """
+
+        if isinstance(X, pd.DataFrame):
+            if self.Xnames is None:
+                self.Xnames = list(X.columns)
+            X_df = X.reset_index(drop=True)
+        else:
+            if self.Xnames is None:
+                raise ValueError("Xnames must be provided when X is not a DataFrame")
+            X_df = pd.DataFrame(X, columns=self.Xnames)
+
+        if isinstance(y, pd.DataFrame):
+            t = y[self.tname].reset_index(drop=True)
+            d = y[self.dname].reset_index(drop=True)
+        else:
+            t = pd.Series(y[:, 0])
+            d = pd.Series(y[:, 1])
+
+        df = pd.concat(
+            [t.rename(self.tname), d.rename(self.dname), X_df.reset_index(drop=True)],
+            axis=1,
+        )
+
+        # self.random_state_ = check_random_state(self.random_state)
         beta = nn.Parameter(torch.zeros(len(self.Xnames))).float()
-        
+
         optimizer = optim.LBFGS([beta], lr=self.lr)
 
-        inputdf = df[[self.tname,self.dname,*self.Xnames]].sort_values([self.dname,self.tname], ascending=[False,True])
+        inputdf = df[[self.tname, self.dname, *self.Xnames]].sort_values(
+            [self.dname, self.tname], ascending=[False, True]
+        )
 
-        tiecountdf = inputdf.loc[inputdf[self.dname]==1,:].groupby([self.tname]).size().reset_index(name='tiecount')
+        tiecountdf = (
+            inputdf.loc[inputdf[self.dname] == 1, :]
+            .groupby([self.tname])
+            .size()
+            .reset_index(name="tiecount")
+        )
         num_tied = torch.from_numpy(tiecountdf.tiecount.values).int()
 
-        tensin = torch.from_numpy(inputdf[[self.tname,self.dname,*self.Xnames]].values)
+        tensin = torch.from_numpy(
+            inputdf[[self.tname, self.dname, *self.Xnames]].values
+        )
 
-        #Get unique event times
-        tensin_events = torch.unique(tensin[tensin[:,1]==1, 0])
+        # Get unique event times
+        tensin_events = torch.unique(tensin[tensin[:, 1] == 1, 0])
 
-        #For each unique event stack another matrix with event at the top, and all at risk entries below
-        tensor = torch.stack([self._padToMatch2d(tensin[tensin[:,0] >= eventtime, :], tensin.shape) for eventtime in tensin_events])
+        # For each unique event stack another matrix with event at the top, and all at risk entries below
+        tensor = torch.stack(
+            [
+                self._padToMatch2d(tensin[tensin[:, 0] >= eventtime, :], tensin.shape)
+                for eventtime in tensin_events
+            ]
+        )
 
-        assert all(tensor[:,0,1] == 1)
+        assert all(tensor[:, 0, 1] == 1)
 
-        #One actually has to sum over the covariates which have a tied event time in the Breslow correction method!
-        #See page 33 here: https://www.math.ucsd.edu/~rxu/math284/slect5.pdf
-        event_tens = torch.stack([tensor[i, :num_tied[i], 2:].sum(dim=0) for i in range(tensor.shape[0])])
+        # One actually has to sum over the covariates which have a tied event time in the Breslow correction method!
+        # See page 33 here: https://www.math.ucsd.edu/~rxu/math284/slect5.pdf
+        event_tens = torch.stack(
+            [tensor[i, : num_tied[i], 2:].sum(dim=0) for i in range(tensor.shape[0])]
+        )
 
-        #Drop time and status columns as no longer required
-        tensor = tensor[:,:,2:]
+        # Drop time and status columns as no longer required
+        tensor = tensor[:, :, 2:]
 
         def closure():
             optimizer.zero_grad()
             loss = self.get_loss(tensor, event_tens, num_tied, beta)
-            #print(loss)
+            # print(loss)
             loss.backward()
             return loss
 
         optimizer.step(closure)
 
         self.beta = beta
-        print(self.beta.detach().numpy())        
-        
-        
-        #Compute baseline hazard during fit() to avoid having to save dataset to memory in TorchCox() objects, so it
+        print(self.beta.detach().numpy())
+
+        # Compute baseline hazard during fit() to avoid having to save dataset to memory in TorchCox() objects, so it
         #  can then later be calculated if basehaz() is called.
         if basehaz:
             t, _ = torch.sort(torch.from_numpy(inputdf[self.tname].values))
@@ -86,29 +132,48 @@ class TorchCox(BaseEstimator):
 
             h0 = []
             for time in t_uniq:
-                value = 1/torch.sum(torch.exp(torch.einsum('ij,j->i', torch.from_numpy(inputdf.loc[inputdf[self.tname] >= time.numpy(), self.Xnames].values).float(), self.beta)))
-                h0.append({'time':time.numpy(), 'h0':value.detach().numpy()})
+                value = 1 / torch.sum(
+                    torch.exp(
+                        torch.einsum(
+                            "ij,j->i",
+                            torch.from_numpy(
+                                inputdf.loc[
+                                    inputdf[self.tname] >= time.numpy(), self.Xnames
+                                ].values
+                            ).float(),
+                            self.beta,
+                        )
+                    )
+                )
+                h0.append({"time": time.numpy(), "h0": value.detach().numpy()})
 
             h0df = pd.DataFrame(h0)
-            h0df['H0'] = h0df.h0.cumsum()
+            h0df["H0"] = h0df.h0.cumsum()
 
             self.basehaz = h0df
 
-        
-    def predict_proba(self, testdf, Xnames=None, tname=None):
-        
-        betas = self.beta.detach().numpy()
-        H0 = np.asarray([self.basehaz.loc[self.basehaz.time<=t, 'H0'].iloc[-1] for t in testdf[tname].values])
+    def predict_proba(self, X, times):
+        """Predict survival probabilities at the given times."""
 
-        S = np.exp(np.multiply(-np.exp(np.dot(testdf[Xnames].values, betas)), H0))
-        
-        assert all(S>=0)
-        assert all(S<=1)
-        
-        #F = 1 - S
-        #assert all(F>=0)
-        #assert all(F<=1)
-        
+        if isinstance(X, pd.DataFrame):
+            X_mat = X[self.Xnames].values
+        else:
+            X_mat = X
+
+        betas = self.beta.detach().numpy()
+        H0 = np.asarray(
+            [self.basehaz.loc[self.basehaz.time <= t, "H0"].iloc[-1] for t in times]
+        )
+
+        S = np.exp(-np.exp(np.dot(X_mat, betas)) * H0)
+        S = np.clip(S, 0, 1)
         return S
 
-
+    def predict(self, X):
+        """Predict the relative risk (partial hazard)."""
+        if isinstance(X, pd.DataFrame):
+            X_mat = X[self.Xnames].values
+        else:
+            X_mat = X
+        beta = self.beta.detach().numpy()
+        return np.exp(np.dot(X_mat, beta))

--- a/src/coxbin/TorchCoxMulti.py
+++ b/src/coxbin/TorchCoxMulti.py
@@ -11,10 +11,22 @@ torch.autograd.set_detect_anomaly(True)
 class TorchCoxMulti(BaseEstimator):
     """Fit a Cox model with an additional logistic regression loss for left-censored observations."""
 
-    def __init__(self, lr=1, alpha=0.5, random_state=None):
+    def __init__(
+        self,
+        lr=1.0,
+        alpha=0.5,
+        random_state=None,
+        *,
+        Xnames=None,
+        tname="time",
+        dname="event",
+    ):
         self.random_state = random_state
         self.lr = lr
         self.alpha = alpha  # Balance between Cox loss and logistic loss
+        self.Xnames = Xnames
+        self.tname = tname
+        self.dname = dname
 
     def _padToMatch2d(self, inputtens, targetshape):
         target = torch.full(targetshape, fill_value=-1e3)
@@ -23,8 +35,8 @@ class TorchCoxMulti(BaseEstimator):
 
     def get_cox_loss(self, tensor, event_tens, num_tied, beta):
         """Compute the Cox regression loss."""
-        loss_event = torch.einsum('ik,k->i', event_tens, beta)
-        XB = torch.einsum('ijk,k->ij', tensor, beta)
+        loss_event = torch.einsum("ik,k->i", event_tens, beta)
+        XB = torch.einsum("ijk,k->ij", tensor, beta)
         loss_atrisk = -num_tied * torch.logsumexp(XB, dim=1)
         loss = torch.sum(loss_event + loss_atrisk)
         return -loss
@@ -49,7 +61,9 @@ class TorchCoxMulti(BaseEstimator):
 
         # Combine cases and controls for logistic regression
         logistic_df = pd.concat([cases_df, controls_df], ignore_index=True)
-        logistic_y = np.where(logistic_df[self.tname] < 1, 1.0, 0.0)  # 1 for cases, 0 for controls
+        logistic_y = np.where(
+            logistic_df[self.tname] < 1, 1.0, 0.0
+        )  # 1 for cases, 0 for controls
 
         return incident_df, logistic_df, logistic_y
 
@@ -67,7 +81,9 @@ class TorchCoxMulti(BaseEstimator):
         )
         num_tied = torch.from_numpy(tiecountdf.tiecount.values).int()
 
-        tensin = torch.from_numpy(inputdf[[self.tname, self.dname, *self.Xnames]].values)
+        tensin = torch.from_numpy(
+            inputdf[[self.tname, self.dname, *self.Xnames]].values
+        )
 
         # Get unique event times
         tensin_events = torch.unique(tensin[tensin[:, 1] == 1, 0])
@@ -106,10 +122,29 @@ class TorchCoxMulti(BaseEstimator):
         loss = (1 - self.alpha) * cox_loss + self.alpha * logistic_loss
         return loss
 
-    def fit(self, df, Xnames=None, tname=None, dname=None, basehaz=True):
-        self.Xnames = Xnames
-        self.tname = tname
-        self.dname = dname
+    def fit(self, X, y, basehaz=True):
+        """Fit the model using (X, y) style arguments."""
+
+        if isinstance(X, pd.DataFrame):
+            if self.Xnames is None:
+                self.Xnames = list(X.columns)
+            X_df = X.reset_index(drop=True)
+        else:
+            if self.Xnames is None:
+                raise ValueError("Xnames must be provided when X is not a DataFrame")
+            X_df = pd.DataFrame(X, columns=self.Xnames)
+
+        if isinstance(y, pd.DataFrame):
+            t = y[self.tname].reset_index(drop=True)
+            d = y[self.dname].reset_index(drop=True)
+        else:
+            t = pd.Series(y[:, 0])
+            d = pd.Series(y[:, 1])
+
+        df = pd.concat(
+            [t.rename(self.tname), d.rename(self.dname), X_df.reset_index(drop=True)],
+            axis=1,
+        )
 
         beta = nn.Parameter(torch.zeros(len(self.Xnames))).float()
         optimizer = optim.LBFGS([beta], lr=self.lr)
@@ -121,18 +156,22 @@ class TorchCoxMulti(BaseEstimator):
         tensor, event_tens, num_tied = self.compute_cox_components(incident_df)
 
         # Compute Logistic components
-        logistic_X, logistic_y = self.compute_logistic_components(logistic_df, logistic_y)
+        logistic_X, logistic_y = self.compute_logistic_components(
+            logistic_df, logistic_y
+        )
 
         def closure():
             optimizer.zero_grad()
-            loss = self.get_loss(tensor, event_tens, num_tied, logistic_X, logistic_y, beta)
+            loss = self.get_loss(
+                tensor, event_tens, num_tied, logistic_X, logistic_y, beta
+            )
             loss.backward()
             return loss
 
         optimizer.step(closure)
 
         self.beta = beta
-        #print("Estimated coefficients:", self.beta.detach().numpy())
+        # print("Estimated coefficients:", self.beta.detach().numpy())
 
         # Compute baseline hazard if required
         if basehaz:
@@ -151,22 +190,30 @@ class TorchCoxMulti(BaseEstimator):
             h0df["H0"] = h0df.h0.cumsum()
             self.basehaz = h0df
 
-    def predict_proba(self, testdf, Xnames=None, tname=None):
+    def predict_proba(self, X, times):
+        """Predict survival probabilities at the given times."""
+        if isinstance(X, pd.DataFrame):
+            X_mat = X[self.Xnames].values
+        else:
+            X_mat = X
+
         betas = self.beta.detach().numpy()
         H0 = np.asarray(
-            [self.basehaz.loc[self.basehaz.time <= t, "H0"].iloc[-1] for t in testdf[tname].values]
+            [self.basehaz.loc[self.basehaz.time <= t, "H0"].iloc[-1] for t in times]
         )
-        S = np.exp(-np.exp(np.dot(testdf[Xnames].values, betas)) * H0)
+        S = np.exp(-np.exp(np.dot(X_mat, betas)) * H0)
         S = np.clip(S, 0, 1)
         return S
 
-    def predict_partial_hazard(self, df):
-        """Compute the partial hazard for the Cox model."""
-        X = torch.from_numpy(df[self.Xnames].values).float()
-        beta = self.beta.detach()
-        risk_scores = torch.exp(X @ beta).numpy()
-        return risk_scores
-    
+    def predict(self, X):
+        """Predict the relative risk (partial hazard)."""
+        if isinstance(X, pd.DataFrame):
+            X_mat = X[self.Xnames].values
+        else:
+            X_mat = X
+        beta = self.beta.detach().numpy()
+        return np.exp(np.dot(X_mat, beta))
+
     def compute_loss(self, df):
         """Compute the combined loss on new data."""
         # Preprocess the data
@@ -176,8 +223,12 @@ class TorchCoxMulti(BaseEstimator):
         tensor, event_tens, num_tied = self.compute_cox_components(incident_df)
 
         # Compute Logistic components
-        logistic_X, logistic_y = self.compute_logistic_components(logistic_df, logistic_y)
+        logistic_X, logistic_y = self.compute_logistic_components(
+            logistic_df, logistic_y
+        )
 
         # Compute the combined loss
-        loss = self.get_loss(tensor, event_tens, num_tied, logistic_X, logistic_y, self.beta)
+        loss = self.get_loss(
+            tensor, event_tens, num_tied, logistic_X, logistic_y, self.beta
+        )
         return loss.item()

--- a/tests/test_torchcox.py
+++ b/tests/test_torchcox.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pandas as pd
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.model_selection import cross_val_score
+from lifelines.utils import concordance_index
+
+from coxbin.TorchCox import TorchCox
+
+
+def _cindex_score(estimator, X, y):
+    times = y[:, 0]
+    events = y[:, 1]
+    risk = estimator.predict(X)
+    return concordance_index(times, -risk, events)
+
+
+def test_torchcox_fit_predict():
+    X = pd.DataFrame({'smoke': [1, 0, 0, 1]})
+    y = pd.DataFrame({'time': [1, 3, 6, 10], 'event': [1, 1, 0, 1]})
+    model = TorchCox(lr=1.0, Xnames=['smoke'])
+    model.fit(X, y)
+    assert model.beta is not None
+    np.testing.assert_allclose(
+        model.beta.detach().numpy()[0], np.log(2) / 2, rtol=1e-4, atol=1e-4
+    )
+    prob = model.predict_proba(X, y['time'])
+    assert prob.shape[0] == len(X)
+    risk = model.predict(X)
+    assert risk.shape[0] == len(X)
+
+
+def test_torchcox_pipeline_integration():
+    X = pd.DataFrame({'smoke': [1, 0, 0, 1, 1, 0, 0, 1]})
+    y = pd.DataFrame({'time': [1, 3, 6, 10, 4, 2, 8, 5], 'event': [1, 1, 0, 1, 0, 1, 1, 0]})
+    pipe = make_pipeline(StandardScaler(), TorchCox(lr=1.0, Xnames=['smoke']))
+    scores = cross_val_score(
+        pipe, X, y[['time', 'event']].values, cv=2, scoring=_cindex_score
+    )
+    assert scores.shape[0] == 2
+    assert not np.isnan(scores).any()

--- a/tests/test_torchcoxmulti.py
+++ b/tests/test_torchcoxmulti.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pandas as pd
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.model_selection import cross_val_score
+from lifelines.utils import concordance_index
+
+from coxbin.TorchCoxMulti import TorchCoxMulti
+
+
+def _cindex_score(estimator, X, y):
+    times = y[:, 0]
+    events = y[:, 1]
+    risk = estimator.predict(X)
+    return concordance_index(times, -risk, events)
+
+
+def test_torchcoxmulti_fit_predict():
+    X = pd.DataFrame({'smoke': [1, 0, 0, 1, 1, 0, 0, 0]})
+    y = pd.DataFrame({'time': [1, 3, 6, 10, -1, 0, -0.5, 1], 'event': [1, 1, 0, 1, 1, 0, 1, 0]})
+    model = TorchCoxMulti(lr=1.0, Xnames=['smoke'])
+    model.fit(X, y)
+    assert model.beta is not None
+    assert not model.basehaz.empty
+    X_pos = X[y['time'] > 0]
+    times = y.loc[y['time'] > 0, 'time']
+    prob = model.predict_proba(X_pos, times)
+    assert prob.shape[0] == len(times)
+
+
+def test_torchcoxmulti_pipeline_integration():
+    X = pd.DataFrame({'smoke': [1, 0, 1, 0, 1, 0, 1, 0, 1, 0]})
+    y = pd.DataFrame({'time': [1, 3, 2, 4, 5, 6, 1.5, 2.5, -1, 0],
+                      'event': [1, 1, 1, 0, 1, 0, 1, 0, 1, 0]})
+    pipe = make_pipeline(StandardScaler(), TorchCoxMulti(lr=1.0, Xnames=['smoke']))
+    scores = cross_val_score(
+        pipe, X, y[['time', 'event']].values, cv=2, scoring=_cindex_score
+    )
+    assert scores.shape[0] == 2
+    assert not np.isnan(scores).any()


### PR DESCRIPTION
## Summary
- test `TorchCox` estimator using new `(X, y)` interface
- test `TorchCoxMulti` estimator and baseline hazard logic
- verify both estimators work inside scikit-learn pipelines

## Testing
- `uv run python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1a39025c83268fa2e43a6c3d7734